### PR TITLE
Unicode support

### DIFF
--- a/src/diagram.js
+++ b/src/diagram.js
@@ -44,7 +44,7 @@ export function toBase64(diagram) {
 }
 
 export function fromBase64(base64) {
-    return fromJSON(atob(base64))
+    return fromJSON(helper.b64DecodeUnicode(base64))
 }
 
 export function toTeX(diagram) {

--- a/src/diagram.js
+++ b/src/diagram.js
@@ -40,7 +40,7 @@ export function fromJSON(json) {
 }
 
 export function toBase64(diagram) {
-    return btoa(toJSON(diagram))
+    return helper.b64EncodeUnicode(toJSON(diagram))
 }
 
 export function fromBase64(base64) {

--- a/src/helper.js
+++ b/src/helper.js
@@ -26,13 +26,13 @@ export function arrSubtract(a, b) {
 
 // to support unicode
 
-function b64EncodeUnicode(str) {
+export function b64EncodeUnicode(str) {
     return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function(match, p1) {
         return String.fromCharCode(parseInt(p1, 16))
     }))
 }
 
-function b64DecodeUnicode(str) {
+export function b64DecodeUnicode(str) {
     return decodeURIComponent(Array.prototype.map.call(atob(str), function(c) {
         return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
     }).join(''))

--- a/src/helper.js
+++ b/src/helper.js
@@ -23,3 +23,17 @@ export function arrScale(m, a) {
 export function arrSubtract(a, b) {
     return a.map((x, i) => x - b[i])
 }
+
+// to support unicode
+
+function b64EncodeUnicode(str) {
+    return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function(match, p1) {
+        return String.fromCharCode(parseInt(p1, 16))
+    }))
+}
+
+function b64DecodeUnicode(str) {
+    return decodeURIComponent(Array.prototype.map.call(atob(str), function(c) {
+        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+    }).join(''))
+}


### PR DESCRIPTION
The functions `btoa` and `atob` used for the encoding to get the link don't support unicode, which is a pity since MathJax does 😅  
Here is a fix (tested locally, it works like a charm) which supports unicode.