### PR TITLE
Prevent ⌘R and friends from being blocked on macOS

### DIFF
--- a/src/components/Properties.js
+++ b/src/components/Properties.js
@@ -29,7 +29,7 @@ export default class Properties extends Component {
         let edgeDelete = [46, 8]    // Delete, Backspace
 
         document.addEventListener('keydown', evt => {
-            if (evt.metaKey || !this.props.show || this.state.edit) return
+            if (evt.ctrlKey || evt.metaKey || !this.props.show || this.state.edit) return
 
             if (edgeControl[evt.keyCode] != null) {
                 evt.preventDefault()

--- a/src/components/Properties.js
+++ b/src/components/Properties.js
@@ -29,7 +29,7 @@ export default class Properties extends Component {
         let edgeDelete = [46, 8]    // Delete, Backspace
 
         document.addEventListener('keydown', evt => {
-            if (!this.props.show || this.state.edit) return
+            if (evt.metaKey || !this.props.show || this.state.edit) return
 
             if (edgeControl[evt.keyCode] != null) {
                 evt.preventDefault()


### PR DESCRIPTION
I think it's reasonable simply not to handle any keys pressed in conjunction with the meta key (which is mainly relevant on macOS). At the moment, it's not possible to refresh the page with ⌘R.