### PR TITLE
UX improvements

### DIFF
--- a/css/master.css
+++ b/css/master.css
@@ -270,14 +270,17 @@ a, img {
 }
 
 #root .code-popup {
-        border-radius: 5px;
         position: absolute;
         width: 80%;
         height: 80%;
         left: 10%;
         top: 10%;
+        padding: 8pt 12pt;
         background: rgba(57, 57, 57, .9);
         box-shadow: 0 5px 10px rgba(0, 0, 0, .5);
+        border: none;
+        outline: none;
+        resize: none;
         opacity: 0;
         transform: scale(.7) translate(0, 10%);
         transition: opacity .1s, transform .1s;

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -44,6 +44,7 @@ export default class App extends Component {
 
         let actions = {
             27: 'close',    // Escape
+            90: 'history',  // Z
         }
 
         document.addEventListener('keydown', evt => {
@@ -58,6 +59,14 @@ export default class App extends Component {
                 case 'close':
                     this.codePopup.value = ''
                     this.setState({codePopupOpen: false})
+                    break
+                case 'history':
+                    if (evt.ctrlKey || evt.metaKey) {
+                        if (!evt.shiftKey)
+                            this.undo()
+                        else
+                            this.redo()
+                    }
                     break
             }
         })
@@ -287,14 +296,14 @@ export default class App extends Component {
                 <Button
                     disabled={this.history[this.historyPointer - 1] == null}
                     icon="./img/tools/undo.svg"
-                    name="Undo"
+                    name="Undo (Ctrl+Z or ⌘Z)"
                     onClick={this.undo}
                 />
 
                 <Button
                     disabled={this.history[this.historyPointer + 1] == null}
                     icon="./img/tools/redo.svg"
-                    name="Redo"
+                    name="Redo (Ctrl+Shift+Z or ⇧⌘Z)"
                     onClick={this.redo}
                 />
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -313,6 +313,7 @@ export default class App extends Component {
 
                 <Button
                     checked={this.state.codePopupOpen}
+                    disabled={this.state.codePopupOpen}
                     icon="./img/tools/code.svg"
                     name="Open Popup with Code"
                     onClick={this.openCodePopup}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -91,10 +91,12 @@ export default class App extends Component {
         })
 
         window.addEventListener('beforeunload', evt => {
-            let message = 'Do you really want to leave?'
+            if (this.state.diagram.nodes.length > 0 || this.state.diagram.edges.length > 0) {
+                let message = 'Do you really want to leave?'
 
-            evt.returnValue = message
-            return message
+                evt.returnValue = message
+                return message
+            }
         })
     }
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -42,12 +42,23 @@ export default class App extends Component {
             32: 'pan'       // Space
         }
 
+        let actions = {
+            27: 'close',    // Escape
+        }
+
         document.addEventListener('keydown', evt => {
             if (toolControl[evt.keyCode] != null) {
                 if (this.prevTool != null) return
 
                 this.prevTool = this.state.tool
                 this.setState({tool: toolControl[evt.keyCode]})
+            }
+
+            switch (actions[evt.keyCode]) {
+                case 'close':
+                    this.codePopup.value = ''
+                    this.setState({codePopupOpen: false})
+                    break
             }
         })
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -38,7 +38,7 @@ export default class App extends Component {
         // Switch tool when holding Control and Space
 
         let toolControl = {
-            17: 'arrow',    // Control
+            18: 'arrow',    // Alt
             32: 'pan'       // Space
         }
 
@@ -287,7 +287,7 @@ export default class App extends Component {
                 <Button
                     checked={this.state.tool === 'arrow'}
                     icon="./img/tools/arrow.svg"
-                    name="Arrow Tool (Ctrl)"
+                    name="Arrow Tool (Alt)"
                     onClick={this.handleToolClick('arrow')}
                 />
 

--- a/src/components/Properties.js
+++ b/src/components/Properties.js
@@ -222,7 +222,7 @@ export default class Properties extends Component {
 
                 <Button
                     icon="./img/properties/bendright.svg"
-                    name="Bend Right (Arrow Key Down)"
+                    name="Bend Right (Down Arrow Key)"
                     onClick={this.handleButtonClick('bendright')}
                 />
 
@@ -249,7 +249,7 @@ export default class Properties extends Component {
 
                 <Button
                     icon="./img/properties/bendleft.svg"
-                    name="Bend Left (Arrow Key Up)"
+                    name="Bend Left (Up Arrow)"
                     onClick={this.handleButtonClick('bendleft')}
                 />
 


### PR DESCRIPTION
This PR includes various usability improvements.
- Make the code popup have a style consistent with the toolbar. 
![image](https://user-images.githubusercontent.com/3943692/50100157-a9ee9780-0217-11e9-86c1-4572d63d891d.png)
- Make pressing Escape while the code popup is open close the popup.
- Add Control/Command(-Shift)-Z for undo/redo.
- Use Alt rather than Control for triggering the arrow tool, as Control is used for context menus on macOS.
- Don't ask user if they really want to leave if there's no diagram.
- Allow the code popup to be closed by clicking on the code popup button.