### PR TITLE
Conversion to MathJax 3

### DIFF
--- a/css/master.css
+++ b/css/master.css
@@ -359,3 +359,10 @@ a, img {
   .code-box .buttons li.separator {
     flex: 1;
 }
+
+mjx-merror {
+  color: inherit !important;
+  background-color: transparent !important;
+  padding: 2px;
+  border: 1px solid black;
+}

--- a/index.html
+++ b/index.html
@@ -11,8 +11,6 @@
 
     <link rel="stylesheet" href="./css/master.css" />
     <link rel="shortcut icon" href="./favicon.ico" type="image/x-icon" />
-
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-AMS_CHTML"></script>
   </head>
   <body>
     <script src="./bundle.js"></script>

--- a/src/components/GridCell.js
+++ b/src/components/GridCell.js
@@ -29,6 +29,8 @@ export default class GridCell extends Component {
         })
       })
     } else {
+      MathJax.typesetClear(this.valueElement)
+      this.valueElement.innerHTML = `<span class="hide">_</span>`
       onTypesetFinish({
         position: this.props.position,
         element: null

--- a/src/components/GridCell.js
+++ b/src/components/GridCell.js
@@ -17,18 +17,15 @@ export default class GridCell extends Component {
   componentDidUpdate(prevProps) {
     let {onTypesetFinish = () => {}} = this.props
 
-    for (let el of this.valueElement.querySelectorAll(
-      ['span[id^="MathJax"]', '.MathJax_Preview', 'script'].join(', ')
-    )) {
-      el.remove()
-    }
-
     if (this.props.value) {
-      MathJax.Hub.Queue(['Typeset', MathJax.Hub, this.valueElement])
-      MathJax.Hub.Queue(() => {
+      // "Re-render" the value element to give to MathJax
+      MathJax.typesetClear(this.valueElement)
+      this.valueElement.innerHTML = `\\(${this.props.value}\\)`
+
+      MathJax.typesetPromise([this.valueElement]).then(() => {
         onTypesetFinish({
           position: this.props.position,
-          element: this.valueElement.querySelector('.MathJax_Preview + span')
+          element: this.valueElement.querySelector('mjx-container')
         })
       })
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,6 @@
 import {h, render} from 'preact'
 import App from './components/App'
 
-// Render
-
-render(<App />, document.body)
-
 // Configure MathJax
 
 window.MathJax = {
@@ -12,7 +8,12 @@ window.MathJax = {
   loader: {load: ['[tex]/noerrors']},
   startup: {
     // No typeset at startup
-    typeset: false
+    typeset: false,
+    // Render main component when MathJax is ready
+    ready: () => {
+      MathJax.startup.defaultReady()
+      render(<App />, document.body)
+    }
   },
   tex: {
     // Use noerrors package

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,39 @@
 import {h, render} from 'preact'
 import App from './components/App'
 
-// Configure MathJax
-
-MathJax.Hub.processSectionDelay = 0
-MathJax.Hub.processUpdateDelay = 0
-
-MathJax.Hub.Config({
-  messageStyle: 'none',
-  skipStartupTypeset: true,
-  showMathMenu: false,
-  errorSettings: {message: ['']}
-})
-
 // Render
 
 render(<App />, document.body)
+
+// Configure MathJax
+
+window.MathJax = {
+  // Load noerrors extension to display raw invalid TeX
+  loader: {load: ['[tex]/noerrors']},
+  startup: {
+    // No typeset at startup
+    typeset: false
+  },
+  tex: {
+    // Use noerrors package
+    packages: {'[+]': ['noerrors']},
+    // Set delimiters for inline math
+    inlineMath: [['\\(', '\\)']]
+  },
+  chtml: {
+    // Set mjx-merror elements to use TeX fonts instead of default browser font
+    merrorFont: ''
+  },
+  options: {
+    // Disable contextual menu
+    enableMenu: false
+  }
+}
+
+// Load MathJax
+
+let script = document.createElement('script')
+script.src =
+  'https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.2/es5/tex-chtml.js'
+script.async = true
+document.head.appendChild(script)


### PR DESCRIPTION
As discussed in [this issue](https://github.com/yishn/tikzcd-editor/issues/48), a move to MathJax 3 is likely to fix the offending obscure MathJax bug.

This was a minor ordeal, but I took the plunge and did it, with some relatively thorough testing to ensure feature parity.

Besides the obvious API changes, there are some major structural changes to the code that I'll outline here for your reviewing convenience:

### Loading and Configuration

The story here is quite different. Now the main bundle file does the following as the first JS that runs:

* Configures the `window.MathJax` object
* Loads the MathJax script programatically (which reads the configuration).
* Renders the main component

This was the best solution I could come up with to resolve loading order difficulties (the config object must exist before the library is loaded, etc.), but you may have better ideas here

### Ensure the library is loaded before using the API

The other trouble was with components using the MathJax api before it was ready (particularly apparent when loading from a hash url); I'm much less confident in my solution here since I'm much more of a Vue guy, so I'm not sure if my solution is idomatic in a react-like environment: 

* Have the main bundle file hook into a `ready` event from MathJax and re-render `App` with a prop `mathjaxLoaded={true}`;
* This prop gets passed down only two levels to `Grid`, where it avoids setting the `value` fields of `GridCell` and `GridArrow` unless the prop is true (and of course when it does, a re-render will trigger and the typesetting will appear).

I separated this part into a separate commit in case you have any better ideas on how to tackle this. In general, loading the library asynchronously and enforcing the library's readiness as a precondition is a huge pain in cases like these.

-----

I also have the current build hosted at [https://cemulate.github.io/tikzcd-editor](https://cemulate.github.io/tikzcd-editor), if you'd like to do any testing yourself. [Here](https://cemulate.github.io/tikzcd-editor/#N4Igdg9gJgpgziAXAbVABwnAlgFyxMJZABgBoBGAXVJADcBDAGwFcYkQBBEAX1PU1z5CKAEyli1Ok1bsAQjz4gM2PASIBWcZIYs2iEPQB6InpJhQA5vCKgAZgCcIAWyRkQOCEnI0dM-QA8QGgAjGDAoJAAWAE4aRnpQxgAFAVVhEEYYWxwgkDgACyxs1147RxdEb3dPRDEMhJhk1KF2TOKfaT0DQ1zGLDAuqHoC8wUy5yQ6jy8QsIjEGI7ddn9jAGoAHQ24AEd7HGB-TY2HegBjYBxuYDBubl7+wYhmYMzc-Jh6ebBmRkYaHD0LCMdiQAambhAA) is a non-trivial hash url to use.