### PR TITLE
Allow nodes to be dragged on to empty cells

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -287,6 +287,7 @@ export default class App extends Component {
           }
         : {})
     }))
+    console.log(this.state.diagram.nodes)
   }
 
   handleCellClick = evt => {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -254,7 +254,8 @@ export default class App extends Component {
     return this.moveInHistory(1)
   }
 
-  handleDataChange = evt => {
+  handleDataChange = (evt, overwriteLastHistory = false) => {
+    if (overwriteLastHistory) this.historyPointer--
     let edgeAdded =
       this.state.diagram.edges.length + 1 === evt.data.edges.length
     let historyEntry = {diagram: evt.data, time: Date.now()}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -287,7 +287,6 @@ export default class App extends Component {
           }
         : {})
     }))
-    console.log(this.state.diagram.nodes)
   }
 
   handleCellClick = evt => {

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -74,7 +74,6 @@ export default class Grid extends Component {
       }
       if (nodesToJoin != null) {
         let {draggedNode, existingNode} = nodesToJoin
-        console.log(nodesToJoin)
         if (draggedNode.id !== existingNode.id) {
           let [textNode, emptyNode] =
             draggedNode.value.length > 0
@@ -82,7 +81,6 @@ export default class Grid extends Component {
               : [existingNode, draggedNode]
 
           let {onDataChange = () => {}} = this.props
-          console.log('merge')
           onDataChange(
             {
               data: {
@@ -154,7 +152,6 @@ export default class Grid extends Component {
         this.setState({nodesToJoin})
 
         let {onDataChange = () => {}} = this.props
-        console.log('move')
         onDataChange({
           selectedCell: newPosition,
           data: {

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -85,9 +85,9 @@ export default class Grid extends Component {
           onDataChange({
             data: {
               nodes: this.props.data.nodes
-                .filter(node => node.id != textNode.id)
+                .filter(node => node.id !== textNode.id)
                 .map(node =>
-                  node.id == emptyNode.id
+                  node.id === emptyNode.id
                     ? {
                         ...emptyNode,
                         position: existingNode.position,
@@ -96,9 +96,9 @@ export default class Grid extends Component {
                     : node
                 ),
               edges: this.props.data.edges.map(edge => {
-                if (edge.from == textNode.id) edge.from = emptyNode.id
-                if (edge.to == textNode.id) edge.to = emptyNode.id
-                if (edge.to == edge.from)
+                if (edge.from === textNode.id) edge.from = emptyNode.id
+                if (edge.to === textNode.id) edge.to = emptyNode.id
+                if (edge.to === edge.from)
                   edge = {...edge, loop: [0, false], labelPosition: 'right'}
                 return edge
               })

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -67,7 +67,7 @@ export default class Grid extends Component {
           ]
 
           let {onDataChange = () => {}} = this.props
-          onDataChange({data: {nodes: newNodes, edges: newEdges}})
+          onDataChange({data: {nodes: newNodes, edges: newEdges}}, true)
         }
 
         this.setState({phantomArrow: null})
@@ -98,6 +98,8 @@ export default class Grid extends Component {
               edges: this.props.data.edges.map(edge => {
                 if (edge.from == textNode.id) edge.from = emptyNode.id
                 if (edge.to == textNode.id) edge.to = emptyNode.id
+                if (edge.to == edge.from)
+                  edge = {...edge, loop: [0, false], labelPosition: 'right'}
                 return edge
               })
             }
@@ -108,7 +110,7 @@ export default class Grid extends Component {
 
     document.addEventListener('mousemove', evt => {
       if (this.mouseDown == null) return
-      
+
       evt.preventDefault()
 
       let newPosition = this.coordsToPosition([evt.clientX, evt.clientY])
@@ -127,8 +129,8 @@ export default class Grid extends Component {
         let {nodeIndex, node: draggedNode} = this.mouseDown
         if (nodeIndex < 0) return
 
-        let existingNode = this.props.data.nodes.find(n =>
-          arrEquals(n.position, newPosition)
+        let existingNode = this.props.data.nodes.find(
+          n => arrEquals(n.position, newPosition) && draggedNode.id != n.id
         )
 
         let nodesToJoin = null


### PR DESCRIPTION
Nodes can be merged now. Merging nodes A and B only works, if at least one node doesn't contain text (is empty).
Merging can be done by dragging:
- an empty node onto another empty node
- an empty node onto a text node
- a text node onto an empty node

Dragging the base of an arrow to the target of it, turns the arrow into a loop.

Everything seems to be working fine, but I'm not 100% sure I caught all bugs, so tell me if I introduced any bugs.