### PR TITLE
Added a preview function for screenshot purposes

### DIFF
--- a/css/master.css
+++ b/css/master.css
@@ -82,9 +82,6 @@ a, img {
 .grid-cell {
     position: relative;
     display: grid;
-    border: 2px dashed #ccc;
-    border-top: none;
-    border-left: none;
     overflow: hidden;
     white-space: nowrap;
     transition: background-color .2s, box-shadow .2s, transform .2s;
@@ -93,6 +90,11 @@ a, img {
     background: white;
     box-shadow: 0 5px 1rem rgba(0, 0, 0, .3);
     transform: scale(1.1);
+  }
+  .grid-cell.show-border {
+    border: 2px dashed #ccc;
+    border-top: none;
+    border-left: none;
   }
   .grid-cell.selected {
     background: #eee;

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -13,7 +13,7 @@ export default class App extends Component {
     super()
 
     this.state = {
-      tool: 'pan',
+      tool: 'pan', // Options: pan, arrow, preview
       cellSize: 130,
       diagram: {nodes: [], edges: []},
 
@@ -48,7 +48,7 @@ export default class App extends Component {
 
     document.addEventListener('keydown', evt => {
       if (toolControl[evt.key] != null) {
-        if (this.prevTool != null) return
+        if (this.prevTool != null || this.state.tool === 'preview') return
 
         this.prevTool = this.state.tool
         this.setState({tool: toolControl[evt.key]})
@@ -386,10 +386,13 @@ export default class App extends Component {
           data={this.state.diagram}
           mode={this.state.tool}
           selectedCell={
-            this.state.selectedArrow == null ? this.state.selectedCell : null
+            this.state.tool !== 'preview' && this.state.selectedArrow == null
+              ? this.state.selectedCell
+              : null
           }
           selectedArrow={this.state.selectedArrow}
           cellEditMode={this.state.cellEditMode}
+          showCellBorders={this.state.tool !== 'preview'}
           onPan={this.handlePan}
           onDataChange={this.handleDataChange}
           onCellClick={this.handleCellClick}
@@ -418,6 +421,13 @@ export default class App extends Component {
             icon="./img/tools/arrow.svg"
             name="Arrow Tool (Shift)"
             onClick={this.handleToolClick('arrow')}
+          />
+
+          <Button
+            checked={this.state.tool === 'preview'}
+            icon="./img/tools/arrow.svg"
+            name="Show/Hide cell borders"
+            onClick={this.handleToolClick('preview')}
           />
 
           <Separator />

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -86,7 +86,10 @@ export default class Grid extends Component {
       this.pointerDown.moved = true
       let newPosition = this.coordsToPosition([evt.clientX, evt.clientY])
 
-      if (this.pointerDown.mode === 'pan') {
+      if (
+        this.pointerDown.mode === 'pan' ||
+        this.pointerDown.mode === 'preview'
+      ) {
         let oldEvt = this.pointerDown.evt
         let oldMouseCoords = [oldEvt.clientX, oldEvt.clientY]
         let newMouseCoords = [evt.clientX, evt.clientY]
@@ -244,7 +247,8 @@ export default class Grid extends Component {
       if (
         this.pointerDown != null &&
         arrEquals(this.pointerDown.position, position) &&
-        !this.pointerDown.moved
+        !this.pointerDown.moved &&
+        this.props.mode !== 'preview'
       ) {
         this.handleCellGrabberPointerDown(evt)
       }
@@ -398,7 +402,7 @@ export default class Grid extends Component {
       <section
         ref={el => (this.element = el)}
         id="grid"
-        class={this.props.mode}
+        class={this.props.mode === 'preview' ? 'pan' : this.props.mode}
       >
         <ol
           style={{
@@ -438,6 +442,7 @@ export default class Grid extends Component {
                         arrEquals(position, this.state.movingNodePosition)
                       }
                       edit={selected && this.props.cellEditMode}
+                      showBorder={this.props.showCellBorders}
                       value={node && node.value}
                       onGrabberPointerDown={this.handleCellGrabberPointerDown}
                       onAddLoopClick={this.handleCellAddLoopClick}

--- a/src/components/GridCell.js
+++ b/src/components/GridCell.js
@@ -1,4 +1,4 @@
-import {h, Component} from 'preact'
+import {h, Component, Fragment} from 'preact'
 import classNames from 'classnames'
 
 export default class GridCell extends Component {
@@ -11,7 +11,8 @@ export default class GridCell extends Component {
       nextProps.value !== this.props.value ||
       nextProps.edit !== this.props.edit ||
       nextProps.selected !== this.props.selected ||
-      nextProps.moving !== this.props.moving
+      nextProps.moving !== this.props.moving ||
+      nextProps.showBorder !== this.props.showBorder
     )
   }
 
@@ -100,7 +101,8 @@ export default class GridCell extends Component {
         class={classNames('grid-cell', {
           edit: this.props.edit,
           selected: this.props.selected,
-          moving: this.props.moving
+          moving: this.props.moving,
+          'show-border': this.props.showBorder
         })}
         data-position={this.props.position.join(',')}
       >
@@ -126,20 +128,24 @@ export default class GridCell extends Component {
           </form>
         )}
 
-        <img
-          class="grabber"
-          src="./img/grabber.svg"
-          onPointerDown={this.handleGrabberPointerDown}
-          onDragStart={this.handleGrabberDragStart}
-        />
+        {this.props.showBorder && (
+          <>
+            <img
+              class="grabber"
+              src="./img/grabber.svg"
+              onPointerDown={this.handleGrabberPointerDown}
+              onDragStart={this.handleGrabberDragStart}
+            />
 
-        <img
-          class="loop"
-          src="./img/loop.svg"
-          title="Create Loop"
-          alt="Create Loop"
-          onClick={this.handleAddLoop}
-        />
+            <img
+              class="loop"
+              src="./img/loop.svg"
+              title="Create Loop"
+              alt="Create Loop"
+              onClick={this.handleAddLoop}
+            />
+          </>
+        )}
       </li>
     )
   }

--- a/src/helper.js
+++ b/src/helper.js
@@ -42,7 +42,7 @@ export function arrSubtract(a, b) {
 
 export function b64EncodeUnicode(str) {
   return btoa(
-    encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function (match, p1) {
+    encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function(match, p1) {
       return String.fromCharCode(parseInt(p1, 16))
     })
   )
@@ -51,7 +51,7 @@ export function b64EncodeUnicode(str) {
 export function b64DecodeUnicode(str) {
   return decodeURIComponent(
     Array.prototype.map
-      .call(atob(str), function (c) {
+      .call(atob(str), function(c) {
         return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
       })
       .join('')


### PR DESCRIPTION
I was taking an online class over the summer using Zulip and many of us found ourselves using this service to quickly draw a commutative diagram to share with others. Having a mode without borders would allow for nicer screenshots. One work item remaining before merging: this feature needs an icon. It seems like your icons were made in illustrator, which I don't have, so would you be willing to create one for me?